### PR TITLE
Add helper to create sample spreadsheet

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -5,6 +5,17 @@ function onInstall() {
   setup();
 }
 
+/** Create a starter spreadsheet */
+function createExampleSpreadsheet() {
+  const ss = SpreadsheetApp.create('ATT Bonus & Holiday Pay');
+  const sheets = ['UKGDat', 'Absenses', 'Holiday', 'MonthlyBonus', 'AnnualBonus'];
+  ss.getSheets()[0].setName(sheets[0]);
+  for (let i = 1; i < sheets.length; i++) {
+    ss.insertSheet(sheets[i]);
+  }
+  return ss.getUrl();
+}
+
 /** Setup - ensures nightly trigger and sheet setup */
 function setup() {
   const ss = SpreadsheetApp.getActive();

--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@ as a lightweight database.
 * `index.html` &ndash; A small single page app served by `doGet()` providing a
   dashboard, roster import and reporting tools.
 * `ATT Bonus & Holiday Pay.xlsx` &ndash; Example spreadsheet containing the
-  expected sheet layout.
+  expected sheet layout. If you don't have a sheet yet, you can also run
+  `createExampleSpreadsheet()` from the Apps Script editor to generate one.
 
 To use the project, open the spreadsheet in Google Sheets and attach this Apps
 Script project. The `setup()` function creates nightly triggers and ensures the
 required sheets (`UKGDat`, `Absenses`, `Holiday`, `MonthlyBonus`,
 `AnnualBonus`) exist.
+
+If you run the code from a standalone Apps Script project,
+`SpreadsheetApp.getActive()` will be `null`, causing errors when calling
+`getSheetByName()`. Be sure to bind the script to your spreadsheet and run
+functions like `setup()` from that bound project.
 
 There are no automated tests. Functionality should be verified manually in the
 Apps Script editor after making changes.


### PR DESCRIPTION
## Summary
- add `createExampleSpreadsheet()` to build a starter spreadsheet if needed
- mention the new helper in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880307513808322917f6d9d371800c0